### PR TITLE
Add local Ollama config for gpt-oss-120b model

### DIFF
--- a/resources/configs/specific/models-config-local-ollama.json
+++ b/resources/configs/specific/models-config-local-ollama.json
@@ -1,0 +1,23 @@
+{
+  "openai_models": {
+    "gpt-oss-120b": {
+      "providers": [
+        {
+          "id": "openai_gpt-oss-120b-ollama-localhost:11434",
+          "api_host": "http://localhost:11434",
+          "api_token": "",
+          "api_type": "ollama",
+          "input_size": 256000,
+          "model_path": "gpt-oss:120b",
+          "keep_alive": "45m",
+          "tool_calling": false
+        }
+      ]
+    }
+  },
+  "active_models": {
+    "openai_models": [
+      "gpt-oss:120b"
+    ]
+  }
+}


### PR DESCRIPTION
- Introduces `models-config-local-ollama.json` containing the configuration for the `gpt-oss-120b` model.
- Enables usage of the `gpt-oss-120b` model with a local Ollama setup.
- No other code changes are included in this PR.