### PR TITLE
Add models() method and AllModelsService for /v1/models

### DIFF
--- a/llm_router_lib/client.py
+++ b/llm_router_lib/client.py
@@ -11,9 +11,10 @@ the model to a plain ``dict`` before invoking the appropriate service.
 import logging
 from typing import Optional, Dict, Any, Union, List
 
-from llm_router_lib.services.ping import PingService
 from llm_router_lib.utils.http import HttpRequester
 from llm_router_lib.exceptions import NoArgsAndNoPayloadError
+from llm_router_lib.services.ping import PingService
+from llm_router_lib.services.models import AllModelsService
 from llm_router_lib.services.utils import (
     TranslateTextService,
     GenerativeAnswerService,
@@ -90,6 +91,10 @@ class LLMRouterClient:
     # ------------------------------------------------------------------ #
     def ping(self) -> Dict[str, Any]:
         return PingService(self.http, self.logger).call_get()
+
+    # ------------------------------------------------------------------ #
+    def models(self) -> Dict[str, Any]:
+        return AllModelsService(self.http, self.logger).call_get()
 
     # ------------------------------------------------------------------ #
     def conversation_with_model(

--- a/llm_router_lib/services/models.py
+++ b/llm_router_lib/services/models.py
@@ -1,0 +1,8 @@
+from llm_router_lib.services.service_interface import (
+    BaseConversationServiceInterface,
+)
+
+
+class AllModelsService(BaseConversationServiceInterface):
+    endpoint = "/v1/models"
+    model_cls = None

--- a/llm_router_lib/tests/llm-router-client.py
+++ b/llm_router_lib/tests/llm-router-client.py
@@ -9,6 +9,7 @@ from llm_router_lib.tests.builtin_conversation import (
 )
 from llm_router_lib.tests.builtin_ping import PingTest
 from llm_router_lib.tests.builtin_utils import TranslateTextModelTest
+from llm_router_lib.tests.models_list import AllModelsTest
 
 
 class Models:
@@ -23,6 +24,7 @@ def prepare_tests(client: LLMRouterClient):
         [AnswerBasedOnTheContextModelTest(client=client), Models.google_gemma_vllm],
         [TranslateTextModelTest(client=client), Models.speakleash_bielik_2_3],
         [PingTest(client=client), None],
+        [AllModelsTest(client=client), None],
     ]
 
 

--- a/llm_router_lib/tests/models_list.py
+++ b/llm_router_lib/tests/models_list.py
@@ -1,0 +1,9 @@
+from llm_router_lib.tests.base import BaseEndpointTest
+
+
+class AllModelsTest(BaseEndpointTest):
+    payload = None
+    payload_model = None
+
+    def client_method(self):
+        return self._client.models


### PR DESCRIPTION
Implemented a new `models()` client method that returns the list of available models.  
Created `AllModelsService` to handle requests to the `/v1/models` endpoint.  
Added `AllModelsTest` to the test suite to verify the new functionality.  
Updated the overall test suite to include the new test case.