### PR TITLE
Add version endpoint and improve documentation

### DIFF
--- a/llm_router_lib/README.md
+++ b/llm_router_lib/README.md
@@ -2,55 +2,60 @@
 
 ## Overview
 
-`llm_router_lib` is ** a collection of data‑model definitions**.
-It supplies the **foundation** for request/response structures used by the
-`llm_router_api` package **and** provides a **thin, opinionated client wrapper**
-that makes interacting with the LLM Router service straightforward.
+`llm_router_lib` bundles **Pydantic data‑model definitions** **and** a **thin, opinionated client wrapper** for the
+LLM‑Router service.
 
-Key components:
+- The **data models** live in `llm_router_lib/data_models` and describe every request payload the router accepts.
+- The **client** (`LLMRouterClient`) offers a high‑level, Pythonic API that hides HTTP details, retries, and error
+  handling.
+- Low‑level **service classes** (`ConversationService`, `ExtendedConversationService`, `TranslateTextService`,
+  `GenerativeAnswerService`, health services) perform the actual HTTP calls and can be used directly when finer‑grained
+  control is required.
+- `HttpRequester` (in `utils/http.py`) is a small wrapper around `requests` that adds logging, configurable retries, and
+  unified error translation.
+- A dedicated **exception hierarchy** (`exceptions.py`) maps HTTP errors to meaningful Python exceptions.
 
-| Package             | Purpose                                                                                                                                                                                                                                                                                                                                                    |
-|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **`data_models`**   | `pydantic` models that define the shape of payloads sent to the router (e.g. `GenerativeConversationModel`, `ExtendedGenerativeConversationModel`, utility models for question generation, translation, etc.). These models are shared with the API side, ensuring both client and server speak the same contract.                                         |
-| **`client.py`**     | `LLMRouterClient` – a lightweight wrapper around the router’s HTTP API. It offers high‑level methods (`conversation_with_model`, `extended_conversation_with_model`) that accept either plain dictionaries **or** the aforementioned data‑model instances. The client handles payload validation, provider selection, error mapping, and response parsing. |
-| **`services`**      | Low‑level service classes (`ConversationService`, `ExtendedConversationService`) that perform the actual HTTP calls via `HttpRequester`. They are used internally by the client but can be reused directly if finer‑grained control is needed.                                                                                                             |
-| **`exceptions.py`** | Custom exception hierarchy (`LLMRouterError`, `AuthenticationError`, `RateLimitError`, `ValidationError`) that mirrors the router’s error semantics, making error handling in user code clean and explicit.                                                                                                                                                |
-| **`utils/http.py`** | `HttpRequester` – a small wrapper around `requests` providing retries, time‑outs and logging. It is the networking backbone for the client wrapper.                                                                                                                                                                                                        |
-
-In short, `llm_router_lib` provides **both** the data contract (the “schema”) **and** a convenient Pythonic client to
-consume the router service.
+In short, `llm_router_lib` provides **both** the contract (the “schema”) **and** a convenient client to consume the
+router service.
 
 ## Installation
 
 The library targets **Python 3.10.6** and uses a `virtualenv`. Install it in editable mode for development:
 
-``` bash
+```bash
+
 # Clone the repository (if you haven't already)
+
 git clone https://github.com/radlab-dev-group/llm-router.git
 cd llm-router/llm_router_lib
 
 # Create and activate a virtual environment
+
 python3 -m venv .venv
 source .venv/bin/activate
 
 # Install the package and its dependencies
+
 pip install -e .
 ```
 
-All runtime dependencies (`requests`, `pydantic`, `rdl_ml_utils`) are declared in the project’s `requirements.txt`.
+All runtime dependencies (`requests`, `pydantic`, plus the packages listed in `requirements.txt`) are declared in the
+project’s `requirements.txt`.
 
 ## Quick start
 
-``` python
+```python
 from llm_router_lib import LLMRouterClient
 
-# Initialise the client – point it at the router’s base URL
+# Initialise the client – point it at the router’s host (do **not** include the `/api` prefix)
+
 client = LLMRouterClient(
-    api="http://localhost:8080/api",   # router base URL
-    token="YOUR_ROUTER_TOKEN",         # optional, if router requires auth
+    api="http://localhost:8080",  # router host URL
+    token="YOUR_ROUTER_TOKEN",  # optional, if router requires auth
 )
 
 # Build a payload using the provided data model (validation is automatic)
+
 payload = {
     "model_name": "google/gemma-3-12b-it",
     "user_last_statement": "Hello, how are you?",
@@ -59,15 +64,15 @@ payload = {
 }
 
 # Call the standard conversation endpoint
+
 response = client.conversation_with_model(payload)
 
-print(response)   # → {'status': True, 'body': {...}}
+print(response)  # → {'status': True, 'body': {...}}
 ```
 
 You can also pass a `pydantic` model instance directly:
 
-```
-python
+```python
 from llm_router_lib.data_models.builtin_chat import GenerativeConversationModel
 
 model = GenerativeConversationModel(
@@ -83,9 +88,9 @@ response = client.conversation_with_model(model)
 ## Data models
 
 All request payloads are defined in `llm_router_lib/data_models`.  
-Common base:
+A common base class supplies shared options:
 
-``` python
+```python
 class BaseModelOptions(BaseModel):
     """Options shared across many endpoint models."""
     mask_payload: bool = False
@@ -99,21 +104,92 @@ class BaseModelOptions(BaseModel):
 | `GenerativeConversationModel`         | `model_name`, `user_last_statement` | `temperature`, `max_new_tokens`, `historical_messages`, … |
 | `ExtendedGenerativeConversationModel` | All of the above + `system_prompt`  | –                                                         |
 
-Utility models for other built‑in endpoints (question generation, translation,
-article creation, context‑based answering, etc.) follow the same pattern and
-inherit from `BaseModelOptions`.
+### Utility models (selected examples)
+
+| Model                                 | Required fields                        | Optional fields (generation parameters)                                   |
+|---------------------------------------|----------------------------------------|---------------------------------------------------------------------------|
+| `GenerateQuestionFromTextsModel`      | `texts` + `model_name`                 | `number_of_questions`, generation opts                                    |
+| `GenerateArticleFromTextModel`        | `text` + `model_name`                  | generation opts                                                           |
+| `TranslateTextModel`                  | `texts` + `model_name`                 | generation opts                                                           |
+| `AnswerBasedOnTheContextModel`        | `question_str`, `texts` + `model_name` | `doc_name_in_answer`, `question_prompt`, `system_prompt`, generation opts |
+| `OpenAIChatModel` (OpenAI‑compatible) | `model`, `messages`                    | `stream`, `keep_alive`, `language`, `options`                             |
+
+*(All utility models inherit from `BaseModelOptions` and therefore share the `mask_payload` and `masker_pipeline`
+flags.)*
+
+## Services (low‑level wrappers)
+
+If you need direct access to the HTTP layer, the library exposes a set of service classes in `llm_router_lib/services`:
+
+| Service class                 | Endpoint (relative to `api`)            | Payload model (if any)                |
+|-------------------------------|-----------------------------------------|---------------------------------------|
+| `ConversationService`         | `/api/conversation_with_model`          | `GenerativeConversationModel`         |
+| `ExtendedConversationService` | `/api/extended_conversation_with_model` | `ExtendedGenerativeConversationModel` |
+| `TranslateTextService`        | `/api/translate`                        | `TranslateTextModel`                  |
+| `GenerativeAnswerService`     | `/api/generative_answer`                | `AnswerBasedOnTheContextModel`        |
+| `PingService`                 | `/api/ping`                             | *none*                                |
+| `VersionService`              | `/api/version`                          | *none*                                |
+
+These services inherit from `BaseConversationServiceInterface`, which provides `call_post` and `call_get` helpers that
+perform JSON parsing and raise the library‑specific exceptions on failure.
+
+### Example: using a service directly
+
+```python
+from llm_router_lib.services.conversation import ConversationService
+from llm_router_lib.utils.http import HttpRequester
+import logging
+
+http = HttpRequester(base_url="http://localhost:8080", token="...", timeout=10)
+logger = logging.getLogger("demo")
+
+service = ConversationService(http, logger)
+payload = {
+    "model_name": "google/gemma-3-12b-it",
+    "user_last_statement": "Hi!",
+}
+response = service.call_post(payload)
+print(response)
+```
 
 ## Thin client wrapper (`LLMRouterClient`)
 
-`LLMRouterClient` offers a **high‑level API** that abstracts away the low‑level
-HTTP details:
+`LLMRouterClient` aggregates the low‑level services and exposes a concise, high‑level API:
 
-| Method                                      | Description                                                                                                    |
-|---------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| `conversation_with_model(payload)`          | Calls `/api/conversation_with_model`. Accepts a dict **or** a `GenerativeConversationModel`.                   |
-| `extended_conversation_with_model(payload)` | Calls `/api/extended_conversation_with_model`. Accepts a dict **or** an `ExtendedGenerativeConversationModel`. |
+| Method                                                                                                                   | Description                                                                                                                                                                                     |
+|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `conversation_with_model(payload)`                                                                                       | Calls `/api/conversation_with_model`. Accepts a dict **or** a `GenerativeConversationModel`.                                                                                                    |
+| `extended_conversation_with_model(payload)`                                                                              | Calls `/api/extended_conversation_with_model`. Accepts a dict **or** an `ExtendedGenerativeConversationModel`.                                                                                  |
+| `translate(payload=None, texts=None, model=None)`                                                                        | Calls `/api/translate`. Three usage patterns: <br>1️⃣ Pass a ready‑made dict.<br>2️⃣ Pass a `TranslateTextModel` instance.<br>3️⃣ Provide `texts` + `model` and let the client build the model. |
+| `generative_answer(payload=None, model=None, texts=None, question_str=None)`                                             | Calls `/api/generative_answer`. Works with a dict, a `AnswerBasedOnTheContextModel` instance, or explicit arguments.                                                                            |
+| `ping()`                                                                                                                 | Calls `/api/ping` – health‑check endpoint.                                                                                                                                                      |
+| `version()`                                                                                                              | Calls `/api/version` – retrieves router version information.                                                                                                                                    |
+| `translate(...)` and `generative_answer(...)` also raise `NoArgsAndNoPayloadError` if called without required arguments. |
 
-Internally the client:
+All methods return the parsed JSON response (a `dict`). Errors from the underlying HTTP layer are translated into the
+following exceptions (defined in `exceptions.py`):
 
-1. **Validates** the payload (via the corresponding `pydantic` model if a model instance is supplied).
-2. **Selects** an appropriate provider using the router’s load‑balancing
+- `LLMRouterError` – base class for all library‑specific errors.
+- `AuthenticationError` – HTTP 401/403 (invalid or missing token).
+- `RateLimitError` – HTTP 429 (too many requests).
+- `ValidationError` – HTTP 400 (malformed payload).
+- `NoArgsAndNoPayloadError` – client‑side validation when required arguments are missing.
+
+## Utilities
+
+- **`utils/http.py` – `HttpRequester`**  
+  Handles URL construction, bearer‑token injection, configurable retries (via `urllib3.Retry`), and unified error
+  mapping. It returns the raw `requests.Response` after validation.
+
+- **`exceptions.py`** – centralised exception definitions (see above).
+
+## Development & testing
+
+The repository includes a small test harness under `llm_router_lib/tests`. Example usage:
+
+```bash
+python -m llm_router_lib.tests.llm-router-client
+```
+
+This script spins up a `LLMRouterClient` instance and runs a suite of end‑to‑end tests covering conversation, extended
+conversation, translation, generative answering, and health checks.

--- a/llm_router_lib/client.py
+++ b/llm_router_lib/client.py
@@ -11,7 +11,7 @@ the model to a plain ``dict`` before invoking the appropriate service.
 import logging
 from typing import Optional, Dict, Any, Union, List
 
-from llm_router_lib.services.ping import PingService
+from llm_router_lib.services.health import PingService, VersionService
 from llm_router_lib.utils.http import HttpRequester
 from llm_router_lib.exceptions import NoArgsAndNoPayloadError
 from llm_router_lib.services.utils import (
@@ -90,6 +90,9 @@ class LLMRouterClient:
     # ------------------------------------------------------------------ #
     def ping(self) -> Dict[str, Any]:
         return PingService(self.http, self.logger).call_get()
+
+    def version(self) -> Dict[str, Any]:
+        return VersionService(self.http, self.logger).call_get()
 
     # ------------------------------------------------------------------ #
     def conversation_with_model(

--- a/llm_router_lib/client.py
+++ b/llm_router_lib/client.py
@@ -89,9 +89,46 @@ class LLMRouterClient:
 
     # ------------------------------------------------------------------ #
     def ping(self) -> Dict[str, Any]:
+        """
+        Perform a health‑check request against the router.
+
+        This method invokes the ``/api/ping`` endpoint via :class:`PingService`
+        and returns the parsed JSON response.  It is useful for quickly
+        confirming that the service is up and reachable before making more
+        expensive calls.
+
+        Returns
+        -------
+        dict
+            The JSON payload returned by the router, typically containing a
+            ``status`` field (e.g. ``{\"status\": \"ok\"}``).
+
+        Raises
+        ------
+        LLMRouterError
+            Propagated from the underlying service if the HTTP request fails
+            or the response cannot be decoded as JSON.
+        """
         return PingService(self.http, self.logger).call_get()
 
     def version(self) -> Dict[str, Any]:
+        """
+        Retrieve version information for the running router instance.
+
+        Calls the ``/api/version`` endpoint via :class:`VersionService`.  The
+        returned dictionary may include keys such as ``version``, ``commit_hash``,
+        ``build_date`` or other metadata the backend provides.
+
+        Returns
+        -------
+        dict
+            Parsed JSON containing version‑related data.
+
+        Raises
+        ------
+        LLMRouterError
+            Propagated if the request fails or the response is not valid JSON.
+        """
         return VersionService(self.http, self.logger).call_get()
 
     # ------------------------------------------------------------------ #

--- a/llm_router_lib/services/health.py
+++ b/llm_router_lib/services/health.py
@@ -19,6 +19,7 @@ class PingService(BaseConversationServiceInterface):
     model_cls : None
         No request payload model is required for this endpoint.
     """
+
     endpoint = "/api/ping"
     model_cls = None
 
@@ -38,5 +39,6 @@ class VersionService(BaseConversationServiceInterface):
     model_cls : None
         No request payload model is required for this endpoint.
     """
+
     endpoint = "/api/version"
     model_cls = None

--- a/llm_router_lib/services/health.py
+++ b/llm_router_lib/services/health.py
@@ -1,0 +1,42 @@
+from llm_router_lib.services.service_interface import (
+    BaseConversationServiceInterface,
+)
+
+
+class PingService(BaseConversationServiceInterface):
+    """
+    Service wrapper for the health‑check ``/api/ping`` endpoint.
+
+    This endpoint is typically used to verify that the router service is
+    reachable and operational.  It performs a simple ``GET`` request and
+    returns the JSON payload provided by the backend (commonly something like
+    ``{\"status\": \"ok\"}``).
+
+    Attributes
+    ----------
+    endpoint : str
+        The relative URL of the ping endpoint (``"/api/ping"``).
+    model_cls : None
+        No request payload model is required for this endpoint.
+    """
+    endpoint = "/api/ping"
+    model_cls = None
+
+
+class VersionService(BaseConversationServiceInterface):
+    """
+    Service wrapper for the ``/api/version`` endpoint.
+
+    Retrieves version information about the running router instance.  The
+    endpoint returns a JSON object containing fields such as ``version``,
+    ``commit_hash`` or any other metadata the service chooses to expose.
+
+    Attributes
+    ----------
+    endpoint : str
+        The relative URL of the version endpoint (``"/api/version"``).
+    model_cls : None
+        No request payload model is required for this endpoint.
+    """
+    endpoint = "/api/version"
+    model_cls = None

--- a/llm_router_lib/services/ping.py
+++ b/llm_router_lib/services/ping.py
@@ -1,8 +1,0 @@
-from llm_router_lib.services.service_interface import (
-    BaseConversationServiceInterface,
-)
-
-
-class PingService(BaseConversationServiceInterface):
-    endpoint = "/api/ping"
-    model_cls = None

--- a/llm_router_lib/tests/builtin_health.py
+++ b/llm_router_lib/tests/builtin_health.py
@@ -7,3 +7,11 @@ class PingTest(BaseEndpointTest):
 
     def client_method(self):
         return self._client.ping
+
+
+class VersionTest(BaseEndpointTest):
+    payload = None
+    payload_model = None
+
+    def client_method(self):
+        return self._client.version

--- a/llm_router_lib/tests/llm-router-client.py
+++ b/llm_router_lib/tests/llm-router-client.py
@@ -7,7 +7,7 @@ from llm_router_lib.tests.builtin_conversation import (
     ExtendedConversationWithModelTest,
     AnswerBasedOnTheContextModelTest,
 )
-from llm_router_lib.tests.builtin_ping import PingTest
+from llm_router_lib.tests.builtin_health import PingTest, VersionTest
 from llm_router_lib.tests.builtin_utils import TranslateTextModelTest
 
 
@@ -23,6 +23,7 @@ def prepare_tests(client: LLMRouterClient):
         [AnswerBasedOnTheContextModelTest(client=client), Models.google_gemma_vllm],
         [TranslateTextModelTest(client=client), Models.speakleash_bielik_2_3],
         [PingTest(client=client), None],
+        [VersionTest(client=client), None],
     ]
 
 


### PR DESCRIPTION
- Updated README: clarified library purpose, refreshed installation snippet, enhanced client initialization notes, expanded tables for services and client methods, added a direct service usage example, and improved overall formatting.
- Added detailed docstrings to `LLMRouterClient.ping` and `LLMRouterClient.version`.
- Implemented `/api/version` support via a new `VersionService`, introduced `client.version()` method, and added corresponding tests.
- Renamed `PingService` to a health module and updated all related imports.
- Reformatted health service files to include a separating newline before endpoint definitions.