### PR TITLE
Add messages_ep to API types and update dispatcher

### DIFF
--- a/llm_router_api/core/api_types/dispatcher.py
+++ b/llm_router_api/core/api_types/dispatcher.py
@@ -163,6 +163,8 @@ class ApiTypesDispatcher:
             return self.responses_ep(api_type=api_type)
         elif "embed" in endpoint_url:
             return self.embeddings_ep(api_type=api_type)
+        elif "messages" in endpoint_url:
+            return self.messages_ep(api_type=api_type)
         return self.chat_ep(api_type=api_type)
 
     @classmethod
@@ -189,6 +191,13 @@ class ApiTypesDispatcher:
         Delegate to the proper implementation to get embeddings endpoint path.
         """
         return cls._get_impl(api_type).embeddings_ep()
+
+    @classmethod
+    def messages_ep(cls, api_type: str) -> str:
+        """
+        Delegate to the proper implementation to get messages endpoint path.
+        """
+        return cls._get_impl(api_type).messages_ep()
 
     @classmethod
     def tags(

--- a/llm_router_api/core/api_types/ollama.py
+++ b/llm_router_api/core/api_types/ollama.py
@@ -81,6 +81,10 @@ class OllamaType(ApiTypesI):
         """
         return "api/embed"
 
+    @staticmethod
+    def messages_ep() -> str:
+        return "/v1/messages?beta=true"
+
 
 class OllamaConverters:
     """Namespace for payload‑conversion utilities.

--- a/llm_router_api/core/api_types/types_i.py
+++ b/llm_router_api/core/api_types/types_i.py
@@ -5,14 +5,7 @@ from abc import ABC, abstractmethod
 
 
 class ApiTypesI(ABC):
-    """
-    Abstract base class describing endpoints and HTTP methods for an API type.
-
-    Subclasses must implement:
-    - models_list_ep() and models_list_method()
-    - chat_ep() and chat_method()
-    - completions_ep() and completions_method()
-    """
+    """ """
 
     @staticmethod
     def tags(models_config: Dict[str, Any]) -> Dict[str, Any]:
@@ -195,3 +188,15 @@ class ApiTypesI(ABC):
             Endpoint path (e.g., "/v1/embeddings").
         """
         raise NotImplementedError
+
+    @staticmethod
+    def messages_ep() -> str:
+        """
+        Return the URL path for the messages's endpoint.
+
+        Returns
+        -------
+        str:
+            Endoint path (e.g. "/v1/messages?").
+        """
+        return "/v1/messages"

--- a/llm_router_api/endpoints/builtin/anthropic.py
+++ b/llm_router_api/endpoints/builtin/anthropic.py
@@ -24,9 +24,9 @@ class AnthropicChatHandler(PassthroughI):
         logger_level: Optional[str] = REST_API_LOG_LEVEL,
         prompt_handler: Optional[PromptHandler] = None,
         model_handler: Optional[ModelHandler] = None,
-        ep_name="messages",
+        ep_name="v1/messages",
         method="POST",
-        dont_add_api_prefix: bool = False,
+        dont_add_api_prefix: bool = True,
         api_types: Optional[List[str]] = None,
         direct_return: bool = False,
     ):

--- a/llm_router_api/register/register.py
+++ b/llm_router_api/register/register.py
@@ -167,6 +167,10 @@ class FlaskEndpointRegistrar:
                             "Transfer-Encoding": "chunked",
                             "X-Accel-Buffering": "no",
                             "Connection": "close",
+                            "Cache-Control": "no-cache, no-store, must-revalidate",
+                            "Pragma": "no-cache",
+                            "Expires": "0",
+                            "Vary": "Accept-Encoding",
                         },
                     )
                     response.implicit_sequence_conversion = False


### PR DESCRIPTION
**Changes**
- Introduced `messages_ep` to the API type definitions and extended the dispatcher to handle the `/v1/messages` endpoint, making it compatible with Claude Agent.
- Updated the default Anthropic endpoint to `v1/messages` and enabled the `dont_add_api_prefix` option.
- Added `Cache-Control`, `Pragma`, `Expires`, and `Vary` headers to streaming responses for better caching behavior.