### PR TITLE
Refactor FastMasker init and add test data placeholder

### DIFF
--- a/llm_router_api/endpoints/builtin/masking.py
+++ b/llm_router_api/endpoints/builtin/masking.py
@@ -93,7 +93,8 @@ class FastTextMasking(EndpointWithHttpRequestI):
             direct_return=True,
         )
 
-        self._fast_masker = FastMasker(rules=FastMasker.ALL_MASKER_RULES)
+        # rules=None means that the all masker rules will be used
+        self._fast_masker = FastMasker(rules=None)
 
     @EP.require_params
     def prepare_payload(


### PR DESCRIPTION
- Updated FastMasker initialization to use `rules=None` for clarity, ensuring all masker rules are applied.  
- Added a placeholder file with example data for testing purposes.